### PR TITLE
Fix missing plugin for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "ts-jest": "^29.2.4",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "copy-webpack-plugin": "^11.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add copy-webpack-plugin to dev dependencies so webpack config can load

## Testing
- `npm test` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_685736c620a4832abcd99a238108852c